### PR TITLE
Added property to QuadCurveRadialDirector for allowing enforcement of exact angles.

### DIFF
--- a/AwesomeMenu/QuadCurveMenu/QuadCurveRadialDirector.h
+++ b/AwesomeMenu/QuadCurveMenu/QuadCurveRadialDirector.h
@@ -16,6 +16,7 @@
 @property (nonatomic, assign) CGFloat farRadius;
 @property (nonatomic, assign) CGFloat rotateAngle;
 @property (nonatomic, assign) CGFloat menuWholeAngle;
+@property (nonatomic, assign) BOOL spreadsToEntireWholeAngle;
 
 - (id)initWithMenuWholeAngle:(CGFloat)menuWholeAngle;
 - (id)initWithMenuWholeAngle:(CGFloat)menuWholeAngle andInitialRotation:(CGFloat)rotateAngle;

--- a/AwesomeMenu/QuadCurveMenu/QuadCurveRadialDirector.m
+++ b/AwesomeMenu/QuadCurveMenu/QuadCurveRadialDirector.m
@@ -30,6 +30,7 @@ static CGPoint RotateCGPointAroundCenter(CGPoint point, CGPoint center, float an
 @synthesize farRadius = farRadius_;
 @synthesize rotateAngle = rotateAngle_;
 @synthesize menuWholeAngle = menuWholeAngle_;
+@synthesize spreadsToEntireWholeAngle = spreadsToEntireWholeAngle_;
 
 #pragma mark - Initialization
 
@@ -44,6 +45,8 @@ static CGPoint RotateCGPointAroundCenter(CGPoint point, CGPoint center, float an
         
         self.rotateAngle = rotateAngle;
         self.menuWholeAngle = menuWholeAngle;
+        
+        self.spreadsToEntireWholeAngle = NO;
 
     }
     return self;
@@ -66,7 +69,7 @@ static CGPoint RotateCGPointAroundCenter(CGPoint point, CGPoint center, float an
     CGPoint startPoint = mainMenuItem.center;
     item.startPoint = startPoint;
     
-    float itemAngle = index * self.menuWholeAngle / count;
+    float itemAngle = index * self.menuWholeAngle / (self.spreadsToEntireWholeAngle ? count - 1 : count);
     float xCoefficient = sinf(itemAngle);
     float yCoefficient = cosf(itemAngle);
     


### PR DESCRIPTION
Right now when setting a whole angle of `M_PI` (`180˚`) the last menu
item will be shown at `angle * itemIndex / itemCount`. As a consequence
the last menu item is not shown at `180˚`, as one would expect. For
`~360˚` this makes sense, as it avoids overlapping of menu items, for
anything else it doesn't quite.
My modification keeps the current (odd) behaviour as default, but
allows menu item distribution by extact angles by setting
`radialDirector.spreadsToEntireWholeAngle = YES;`.
